### PR TITLE
Add clock to personal page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ This repository contains a personal page for a fictional person named John Doe. 
 ### Viewing the Personal Page
 
 To view the personal page, open the `index.html` file in a web browser.
+
+### Clock Functionality
+
+The personal page now includes a clock that displays the current time. The clock is updated every second.
+
+To view the clock, open the `index.html` file in a web browser. The clock will be displayed at the bottom of the page.

--- a/clock.js
+++ b/clock.js
@@ -1,0 +1,10 @@
+function updateClock() {
+    const now = new Date();
+    const hours = now.getHours().toString().padStart(2, '0');
+    const minutes = now.getMinutes().toString().padStart(2, '0');
+    const seconds = now.getSeconds().toString().padStart(2, '0');
+    const formattedTime = `${hours}:${minutes}:${seconds}`;
+    document.getElementById('clock').innerHTML = formattedTime;
+}
+
+setInterval(updateClock, 1000);

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Personal Page</title>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <header>
@@ -22,5 +23,7 @@
             <li><a href="https://linkedin.com/in/johndoe">LinkedIn</a></li>
         </ul>
     </section>
+    <div id="clock"></div>
+    <script src="clock.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+#clock {
+    font-size: 2em;
+    text-align: center;
+    padding: 10px;
+    margin: 20px;
+}


### PR DESCRIPTION
Add clock functionality to the personal page.

* **index.html**
  - Add a `<div>` element with id `clock` inside the `<body>` tag.
  - Add a `<script>` tag to include `clock.js` before the closing `</body>` tag.
  - Add a `<link>` tag to include `styles.css` inside the `<head>` tag.

* **clock.js**
  - Create a function `updateClock` to get the current time and format it.
  - Use `setInterval` to call `updateClock` every second.
  - Update the innerHTML of the `clock` element with the formatted time.

* **styles.css**
  - Add CSS rules to style the `clock` element.
  - Center the text and set a font size for the `clock` element.
  - Add padding and margin to the `clock` element.

* **README.md**
  - Update the instructions to mention the clock functionality.
  - Add a section explaining how to view the clock on the personal page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/trlmrl/testCopilotWorkspace?shareId=8db03b28-6c8f-4f9f-a8d0-43fb274c1aa4).