### PR TITLE
Fix clock visibility issue

### DIFF
--- a/clock.js
+++ b/clock.js
@@ -77,4 +77,5 @@ function drawHand(ctx, pos, length, width) {
     ctx.rotate(-pos);
 }
 
+drawClock();
 setInterval(drawClock, 1000);


### PR DESCRIPTION
Add a call to `drawClock()` outside the `setInterval` function to ensure the clock is drawn immediately when the page loads.

* Add `drawClock();` before `setInterval(drawClock, 1000);` in `clock.js`

